### PR TITLE
Load needed chunks in TeleportationManager asynchronously

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>net.sacredlabyrinth.Phaed</groupId>
     <artifactId>PreciousStones</artifactId>
-    <version>1.16.1.4</version>
+    <version>1.16.1.5</version>
     <name>PreciousStones</name>
     <url>https://github.com/elBukkit/PreciousStones</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,34 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.4.2</version>
             </plugin>
+            
+            <!-- Shade plugin -->
+            <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.2.3</version>
+				<configuration>
+					<artifactSet>
+						<includes>
+							<include>io.papermc:paperlib</include>
+						</includes>
+					</artifactSet>
+					<relocations>
+						<relocation>
+							<pattern>io.papermc.lib</pattern>
+							<shadedPattern>net.sacredlabyrinth.Phaed.PreciousStones.shaded.paperlib</shadedPattern>
+						</relocation>
+					</relocations>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 
             <!-- Ant plugin -->
             <plugin>
@@ -202,6 +230,12 @@
             </exclusions>
         </dependency>
         <dependency>
+        	<groupId>io.papermc</groupId>
+        	<artifactId>paperlib</artifactId>
+        	<version>1.0.4</version>
+        	<optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>ant-contrib</groupId>
             <artifactId>ant-contrib</artifactId>
             <version>1.0b3</version>
@@ -236,6 +270,10 @@
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+        	<id>papermc</id>
+        	<url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSPlayerListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSPlayerListener.java
@@ -1273,7 +1273,7 @@ public class PSPlayerListener implements Listener {
 		}
 
 		final Player player = event.getPlayer();
-		final Block block = event.getBlockClicked();
+		final Block block = event.getBlock();
 		final Block liquid = block.getRelative(event.getBlockFace());
 
 		Material mat = event.getBucket();


### PR DESCRIPTION
Addresses #57 

This PR uses PaperLib to load chunks asynchronously before checking the safety of the location and teleporting players.

I noticed a misconception about PaperLib here:

> If anyone wants to make a PR to add this enhancement feel free, the main objective is to also keep compatibility with spigot so it must work with both. When I have time, Ill have a look into how to add this (as I have never added any custom paper stuff into a plugin)

Contrary to what the comment implies, this PR does *NOT* make PreciousStones require Paper to run. It will still run on Spigot as normal. In fact, this is a good example of the crucial distinction between a library and an API - If PreciousStones used the Paper *API,* it would only be able to run on Paper. Instead, PreciousStones will use Paper*Lib*, which has support for both Spigot and Paper.

PaperLib detects the environment (Spigot or Paper) which the server is running and, accordingly, uses different behaviour. On Spigot, these improvements do not exist, so it functions just as if `Player.teleport` was called. On Paper, however, it will use async chunk loading.

--------------------------------------------------------

The PaperLib dependency is shaded and relocated into PreciousStones using the maven-shade-plugin. The dependency is marked optional because it should not be transitive.

This is the first time I have used PaperLib, nor am I familiar with PreciousStones, so a code review would be appropriate, as reviews often are.
