### PR TITLE
Fix Timeout Issues w/ Clans

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
@@ -550,22 +550,33 @@ public class Field extends AbstractVec implements Comparable<Field> {
             return true;
         }
 
-        List<String> groups = PreciousStones.getInstance().getPermissionsManager().getGroups(getWorld(), target);
+        if (target.contains("g:")) {
+            List<String> groups = PreciousStones.getInstance().getPermissionsManager().getGroups(getWorld(), target);
 
-        for (String group : groups) {
-            if (allowed.contains("g:" + group)) {
-                return true;
+            for (String group : groups) {
+                if (allowed.contains("g:" + group)) {
+                    return true;
+                }
             }
+
+            // short-circuit groups
+            return false;
         }
 
-        String clan = PreciousStones.getInstance().getSimpleClansManager().getClan(target);
+        if (target.contains("c:")) {
+            String clan = PreciousStones.getInstance().getSimpleClansManager().getClan(target);
 
-        if (clan != null) {
-            if (allowed.contains("c:" + clan)) {
-                return true;
+            if (clan != null) {
+                if (allowed.contains("c:" + clan)) {
+                    return true;
+                }
             }
+
+            // short-circuit clans
+            return false;
         }
 
+        // TODO: This method is very slow and can cause a lockup on the server thread
         OfflinePlayer offlinePlayer = PreciousStones.getInstance().getServer().getOfflinePlayer(target);
 
         if (offlinePlayer != null) {

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
@@ -550,28 +550,23 @@ public class Field extends AbstractVec implements Comparable<Field> {
             return true;
         }
 
-        if (target.contains("g:")) {
-            List<String> groups = PreciousStones.getInstance().getPermissionsManager().getGroups(getWorld(), target);
+        List<String> groups = PreciousStones.getInstance().getPermissionsManager().getGroups(getWorld(), target);
 
-            for (String group : groups) {
-                if (allowed.contains("g:" + group)) {
-                    return true;
-                }
+        for (String group : groups) {
+            if (allowed.contains("g:" + group)) {
+                return true;
             }
-
-            // short-circuit groups
-            return false;
         }
 
+        String clan;
         if (target.contains("c:")) {
-            String clan = PreciousStones.getInstance().getSimpleClansManager().getClan(target.substring(2), false);
+            clan = PreciousStones.getInstance().getSimpleClansManager().getClan(target.substring(2), false);
+        } else {
+            clan = PreciousStones.getInstance().getSimpleClansManager().getClan(target, true);
+        }
 
-            if (clan != null) {
-                return allowed.contains("c:" + clan);
-            }
-
-            // short-circuit clans
-            return false;
+        if (clan != null) {
+            return allowed.contains("c:" + clan);
         }
 
         // TODO: This method is very slow and can cause a lockup on the server thread

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
@@ -564,12 +564,10 @@ public class Field extends AbstractVec implements Comparable<Field> {
         }
 
         if (target.contains("c:")) {
-            String clan = PreciousStones.getInstance().getSimpleClansManager().getClan(target);
+            String clan = PreciousStones.getInstance().getSimpleClansManager().getClan(target.substring(2), false);
 
             if (clan != null) {
-                if (allowed.contains("c:" + clan)) {
-                    return true;
-                }
+                return allowed.contains("c:" + clan);
             }
 
             // short-circuit clans

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ForceFieldManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ForceFieldManager.java
@@ -1242,7 +1242,7 @@ public final class ForceFieldManager {
         }
 
         // Don't run player checks if the target is a group or clan
-        if (target.contains("c:") || target.contains("g:")) {
+        if (!target.contains("c:")) {
             // Fetch Player
             Player player = Bukkit.getServer().getPlayerExact(target);
 

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ForceFieldManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ForceFieldManager.java
@@ -252,7 +252,7 @@ public final class ForceFieldManager {
         // add allowed clan
 
         if (plugin.getSettingsManager().isAutoAddClan()) {
-            String clan = plugin.getSimpleClansManager().getClan(player.getName());
+            String clan = plugin.getSimpleClansManager().getClan(player.getName(), true);
 
             if (clan != null) {
                 field.addAllowed("c:" + clan);
@@ -1224,66 +1224,76 @@ public final class ForceFieldManager {
     }
 
     /**
-     * Whether the player is allowed in the field
+     * Checks whether or not the target is allowed in the field
      *
      * @param field
      * @param target
-     * @return
+     * @param checkField
+     * @return whether or not the target is allowed in this field
      */
-    public boolean isAllowed(Field field, String target) {
+    public boolean isAllowed(Field field, String target, boolean checkField) {
         if (field == null || target == null) {
             return false;
         }
 
-        Player player = Bukkit.getServer().getPlayerExact(target);
+        // Check if the field has settings
+        if (field.getSettings() == null) {
+            return false;
+        }
 
-        if (player != null) {
-            // allow if admin
+        // Don't run player checks if the target is a group or clan
+        if (target.contains("c:") || target.contains("g:")) {
+            // Fetch Player
+            Player player = Bukkit.getServer().getPlayerExact(target);
 
+            // Allow the player if they are an admin and the field allows allowing
             if (plugin.getPermissionsManager().has(player, "preciousstones.admin.allowed")) {
                 if (!field.hasFlag(FieldFlag.NO_ALLOWING)) {
                     return true;
                 }
             }
-        }
 
-        // false if settings missing
-
-        if (field.getSettings() == null) {
-            return false;
-        }
-
-        // deny if doesn't have the required perms
-
-        if (!field.getSettings().getRequiredPermissionAllow().isEmpty()) {
-            if (!plugin.getPermissionsManager().has(player, "preciousstones.bypass.required-permission")) {
-                if (!plugin.getPermissionsManager().has(player, field.getSettings().getRequiredPermissionAllow())) {
-                    return false;
+            // Deny player if they do not have the required permission
+            if (!field.getSettings().getRequiredPermissionAllow().isEmpty()) {
+                if (!plugin.getPermissionsManager().has(player, "preciousstones.bypass.required-permission")) {
+                    if (!plugin.getPermissionsManager().has(player, field.getSettings().getRequiredPermissionAllow())) {
+                        return false;
+                    }
                 }
             }
         }
 
-        // allow if in global allowed list
-
+        // Allow if the target is in the global allowed list
         if (field.getSettings().inAllowedList(target)) {
             return true;
         }
 
-        // allow if in global deny list
-
+        // Deny if the target is in the global deny list
         if (field.getSettings().inDeniedList(target)) {
             return false;
         }
 
-        // always allow if in war
-
+        // If you're currently in war, allow
         if (plugin.getSettingsManager().isWarAllow()) {
             if (plugin.getSimpleClansManager().inWar(field, target)) {
                 return true;
             }
         }
 
-        return field.isAllowed(target);
+        // Otherwise, allow
+        return !checkField || field.isAllowed(target);
+    }
+
+    /**
+     * Checks whether or not the target is allowed in the field
+     *
+     * @param field
+     * @param target
+     * @return whether or not the target is allowed in this field
+     */
+    @Deprecated
+    public boolean isAllowed(Field field, String target) {
+        return isAllowed(field, target, true);
     }
 
     /**
@@ -1357,43 +1367,46 @@ public final class ForceFieldManager {
     }
 
     /**
-     * Add allowed player to all your force fields
+     * Adds an allowed player to all force fields
      *
      * @param player
      * @param allowedName
-     * @return count of fields allowed
+     * @param isGuest
+     * @return the number of fields this player has been allowed to
      */
     public int allowAll(Player player, String allowedName, boolean isGuest) {
-        List<Field> fields = getOwnersFields(player, FieldFlag.ALL);
+        List<Field> fields = this.getOwnersFields(player, FieldFlag.ALL);
 
         int allowedCount = 0;
-        int notAllowed = 0;
+        int notAllowedCount = 0;
 
-        for (Field field : fields) {
-            if (!plugin.getPermissionsManager().has(player, "preciousstones.bypass.on-disabled")) {
-                if (field.hasFlag(FieldFlag.MODIFY_ON_DISABLED)) {
-                    if (!field.isDisabled()) {
-                        notAllowed++;
-                        continue;
-                    }
-                }
+        // Cache commonly used values so we don't request them for every field
+        boolean bypassModifyOnDisabled = plugin.getPermissionsManager().has(player, "preciousstones.bypass.on-disabled");
+        boolean bypassNoAllowing = plugin.getPermissionsManager().has(player, "preciousstones.bypass.no-allowing");
+
+        for (Field  field : fields) {
+            // Modify on Disabled
+            if (!bypassModifyOnDisabled && field.hasFlag(FieldFlag.MODIFY_ON_DISABLED) && !field.isDisabled()) {
+                notAllowedCount++;
+                continue;
             }
 
-            if (!plugin.getPermissionsManager().has(player, "preciousstones.bypass.no-allowing")) {
-                if (field.hasFlag(FieldFlag.NO_ALLOWING)) {
-                    continue;
-                }
+            // No Allowing
+            if (!bypassNoAllowing && field.hasFlag(FieldFlag.NO_ALLOWING)) {
+                continue;
             }
 
-            if (!isAllowed(field, allowedName)) {
+            // Allow
+            if (isAllowed(field, allowedName, false)) {
                 if (addAllowed(field, allowedName, isGuest)) {
                     allowedCount++;
                 }
             }
         }
 
-        if (notAllowed > 0) {
-            ChatHelper.send(player, "fieldsSkipped", notAllowed);
+        // Notify of skipped fields
+        if (notAllowedCount > 0) {
+            ChatHelper.send(player, "fieldsSkipped", notAllowedCount);
         }
 
         return allowedCount;
@@ -2950,7 +2963,7 @@ public final class ForceFieldManager {
         // add allowed clan
 
         if (plugin.getSettingsManager().isAutoAddClan()) {
-            String clan = plugin.getSimpleClansManager().getClan(owner.getName());
+            String clan = plugin.getSimpleClansManager().getClan(owner.getName(), true);
 
             if (clan != null) {
                 field.addAllowed("c:" + clan);

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/SimpleClansManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/SimpleClansManager.java
@@ -226,21 +226,41 @@ public final class SimpleClansManager {
     }
 
     /**
-     * @param playerName
-     * @return
+     * Gets a clan by the target provided
+     *
+     * @param target
+     * @param isPlayer
+     * @return the clan's tag
      */
-    public String getClan(String playerName) {
+    public String getClan(String target, boolean isPlayer) {
         if (hasSimpleClans()) {
-        	OfflinePlayer player = Bukkit.getOfflinePlayer(playerName);
-        	if (player != null) {
-	            net.sacredlabyrinth.phaed.simpleclans.ClanPlayer cp = simpleClans.getClanManager().getClanPlayer(player);
-	
-	            if (cp != null) {
-	                return cp.getTag();
-	            }
+            if (isPlayer) {
+                OfflinePlayer player = Bukkit.getOfflinePlayer(target);
+                net.sacredlabyrinth.phaed.simpleclans.ClanPlayer cp = simpleClans.getClanManager().getClanPlayer(player);
+
+                if (cp != null) {
+                    return cp.getTag();
+                }
+            } else {
+               net.sacredlabyrinth.phaed.simpleclans.Clan c = simpleClans.getClanManager().getClan(target);
+               if (c != null) {
+                   return c.getTag();
+               }
             }
         }
 
         return null;
     }
+
+    /**
+     * Gets a clan by a player name.
+     *
+     * @param target
+     * @return the clan's tag
+     */
+    @Deprecated
+    public String getClan(String target) {
+        return getClan(target, true);
+    }
+
 }


### PR DESCRIPTION
What was happening was that, if the clan was not found, it would continue forward to check if it is a player. But, the problem is, if we are trying to allow a clan, the player will simply never exist. So it always takes the maximum amount of lookup time to attempt to find a player offline that never exists, not to mention the excessive amount of API requests being made to the Mojang API to attempt to find these players that don't exist.

My PR short-circuits the logic to return false if a clan is not found. From what I can tell, it works the same as before but _doesn't_ lock up the server and speeds up the method for clans tremendously.

Fixes #114 