### PR TITLE
Update pom.xml to use https instead of http in all repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,11 +274,11 @@
     	</repository>
         <repository>
             <id>sk89q</id>
-            <url>http://maven.sk89q.com/repo/</url>
+            <url>https://maven.sk89q.com/repo/</url>
         </repository>
         <repository>
             <id>elMakers</id>
-            <url>http://maven.elmakers.com/repository/</url>
+            <url>https://maven.elmakers.com/repository/</url>
         </repository>
         <repository>
             <id>redprotect-repo</id>


### PR DESCRIPTION
Compiling PreciousStones with the latest maven version throws an error. This is because of repositories using http that latest maven version doesn't allow by default. These two repositories are currently available over https. After basically replacing http with https the project builds correctly.