### PR TITLE
Added Integration with EzChestShop

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
@@ -27,6 +27,7 @@ import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -1607,6 +1608,13 @@ public class PSBlockListener implements Listener {
                 Player player = (Player) event.getPlayer();
 
                 if (FieldFlag.PROTECT_INVENTORIES.applies(field, player)) {
+                    if (plugin.getPermissionsManager().ecsExists) {
+                        TileState state = (TileState) location.getBlock().getState();
+                        if (state.getPersistentDataContainer().has(new NamespacedKey(plugin, "owner"), PersistentDataType.STRING)) {
+                            //means that's the shop and you are allowed to open the menu, not the block's container
+                            return;
+                        }
+                    }
                     event.setCancelled(true);
                     ChatHelper.send(player, "inventoryDeny");
                 }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
@@ -1609,11 +1609,13 @@ public class PSBlockListener implements Listener {
 
                 if (FieldFlag.PROTECT_INVENTORIES.applies(field, player)) {
                     if (plugin.getPermissionsManager().ecsExists) {
-                        TileState state = (TileState) location.getBlock().getState();
-                        if (state.getPersistentDataContainer().has(new NamespacedKey(plugin, "owner"), PersistentDataType.STRING)) {
-                            //means that's the shop and you are allowed to open the menu, not the block's container
-                            return;
-                        }
+			if (location.getBlock() != null) {
+				TileState state = (TileState) location.getBlock().getState();
+				if (state.getPersistentDataContainer().has(new NamespacedKey(plugin, "owner"), PersistentDataType.STRING)) {
+					//means that's the shop and you are allowed to open the menu, not the block's container
+					return;
+				}
+			}
                     }
                     event.setCancelled(true);
                     ChatHelper.send(player, "inventoryDeny");

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/PermissionsManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/PermissionsManager.java
@@ -45,6 +45,7 @@ public final class PermissionsManager {
     private PreciousStones plugin;
     private mcMMO mcmmo = null;
 	private WorldEditPlugin worldEdit = null;
+    public boolean ecsExists = false;
 
     /**
      *
@@ -58,6 +59,7 @@ public final class PermissionsManager {
         detectLockette();
         detectMcMMO();
         detectWorldEdit();
+        detectECS();
 
         try {
             Class.forName("net.milkbowl.vault.permission.Permission");
@@ -83,6 +85,14 @@ public final class PermissionsManager {
 
         if (plug != null) {
             mcmmo = ((mcMMO) plug);
+        }
+    }
+
+    private void detectECS() {
+        Plugin plug = plugin.getServer().getPluginManager().getPlugin("EzChestShop");
+
+        if (plug != null) {
+            ecsExists = true;
         }
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ version: ${project.version}
 api-version: 1.17
 dev-url: https://github.com/elBukkit/PreciousStones
 load: POSTWORLD
-softdepend: [Permissions, PermissionsBukkit, SimpleClans, Vault, CombatTag, WorldGuard, LWC, Lockette, mcMMO, SCCore, WorldEdit]
+softdepend: [Permissions, PermissionsBukkit, SimpleClans, Vault, CombatTag, WorldGuard, LWC, Lockette, mcMMO, SCCore, WorldEdit, EzChestShop]
 commands:
   ps:
     description: All of the PreciousStones commands


### PR DESCRIPTION
Hello there,
One of the PreciousStone users contacted me about EzChestShop not working with PreciousStones, and the problem was this side, and it happens when a GUI opens for a player. EzChestShop uses **InteractionEvent** for opening the shop menu. However, PreciousStones uses **InventoryOpenEvent** and then checks if the player has the permission for opening that inventory in the protected zone, only by checking the block which the user is looking at, during the event. I assume that's not the right way of handling it thou and recommend changing the way or making sure that the GUI is not opened by another plugin. (I'm pretty sure other plugins may face a similar issue). 

but for a temporary solution, here is the fix. 

Kind Regards
